### PR TITLE
fix: add missing CompactU256

### DIFF
--- a/src/extrinsic_decoder.rs
+++ b/src/extrinsic_decoder.rs
@@ -175,7 +175,7 @@ impl CollectAccessedTypes {
 							.fields
 							.iter()
 							.for_each(|f| self.collect_all_types(&f.ty, type_information)),
-						TypeDef::Sequence(s) => self.collect_all_types(&s, type_information),
+						TypeDef::Sequence(s) => self.collect_all_types(s, type_information),
 						TypeDef::Tuple(t) =>
 							t.iter().for_each(|t| self.collect_all_types(t, type_information)),
 						TypeDef::BitSequence(_) => {},
@@ -247,11 +247,11 @@ impl Visitor for CollectAccessedTypes {
 		Ok(self)
 	}
 
-	fn visit_u256<'scale, 'resolver>(
+	fn visit_u256<'resolver>(
 		self,
-		_value: &'scale [u8; 32],
+		_value: &[u8; 32],
 		_type_id: TypeRef,
-	) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
+	) -> Result<Self::Value<'_, 'resolver>, Self::Error> {
 		Ok(self)
 	}
 
@@ -295,11 +295,11 @@ impl Visitor for CollectAccessedTypes {
 		Ok(self)
 	}
 
-	fn visit_i256<'scale, 'resolver>(
+	fn visit_i256<'resolver>(
 		self,
-		_value: &'scale [u8; 32],
+		_value: &[u8; 32],
 		_type_id: TypeRef,
-	) -> Result<Self::Value<'scale, 'resolver>, Self::Error> {
+	) -> Result<Self::Value<'_, 'resolver>, Self::Error> {
 		Ok(self)
 	}
 
@@ -312,7 +312,7 @@ impl Visitor for CollectAccessedTypes {
 			.insert(TypeId::Other(type_id.id().expect("Sequence is always referenced by id; qed")));
 
 		let mut visitor = self;
-		while let Some(field) = value.next() {
+		for field in value.by_ref() {
 			visitor = field?.decode_with_visitor(visitor)?;
 		}
 
@@ -334,7 +334,7 @@ impl Visitor for CollectAccessedTypes {
 		));
 
 		let mut visitor = self;
-		while let Some(field) = value.next() {
+		for field in value.by_ref() {
 			visitor = field?.decode_with_visitor(visitor)?;
 		}
 
@@ -350,7 +350,7 @@ impl Visitor for CollectAccessedTypes {
 			.insert(TypeId::Other(type_id.id().expect("Tuple is always referenced by id; qed")));
 
 		let mut visitor = self;
-		while let Some(field) = value.next() {
+		for field in value.by_ref() {
 			visitor = field?.decode_with_visitor(visitor)?;
 		}
 
@@ -393,7 +393,7 @@ impl Visitor for CollectAccessedTypes {
 		));
 
 		let mut visitor = self;
-		while let Some(field) = value.next() {
+		for field in value.by_ref() {
 			visitor = field?.decode_with_visitor(visitor)?;
 		}
 

--- a/src/from_frame_metadata.rs
+++ b/src/from_frame_metadata.rs
@@ -224,6 +224,7 @@ impl<T> AsBasicTypeRef for UntrackedSymbol<T> {
 						scale_info::TypeDefPrimitive::U32 => types::TypeRef::CompactU32,
 						scale_info::TypeDefPrimitive::U64 => types::TypeRef::CompactU64,
 						scale_info::TypeDefPrimitive::U128 => types::TypeRef::CompactU128,
+						scale_info::TypeDefPrimitive::U256 => types::TypeRef::CompactU256,
 						p => return Err(format!("Unsupported primitive type for `Compact`: {p:?}")),
 					}
 				} else {

--- a/src/from_frame_metadata.rs
+++ b/src/from_frame_metadata.rs
@@ -79,12 +79,11 @@ impl FrameMetadataPrepared {
 		let frame_id_to_id = self
 			.accessible_types
 			.iter()
-			.filter_map(|id| {
-				self.get_type(*id).is_basic_type().then(|| {
-					let new_id = next_id;
-					next_id += 1;
-					(*id, new_id)
-				})
+			.filter(|&id| self.get_type(*id).is_basic_type())
+			.map(|id| {
+				let new_id = next_id;
+				next_id += 1;
+				(*id, new_id)
 			})
 			.collect::<BTreeMap<u32, u32>>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn generate_metadata_digest(
 
 	let type_information = prepared.as_type_information()?;
 
-	let tree_root = MerkleTree::new(type_information.types.into_iter()).root();
+	let tree_root = MerkleTree::new(type_information.types).root();
 
 	Ok(MetadataDigest::V1 {
 		types_tree_root: tree_root,
@@ -228,7 +228,7 @@ mod tests {
 			let metadata = RuntimeMetadataPrefixed::decode(&mut &metadata[..]).unwrap().1;
 
 			let digest = generate_metadata_digest(&metadata, extra_info.clone()).unwrap();
-			assert_eq!(*expected_hash, array_bytes::bytes2hex("0x", &digest.hash()));
+			assert_eq!(*expected_hash, array_bytes::bytes2hex("0x", digest.hash()));
 
 			let prepared = FrameMetadataPrepared::prepare(&metadata).unwrap();
 


### PR DESCRIPTION
While implementing the algorithm in TS I found that this implementation was not feature complete with the RFC. CompactU256 was missing! It's not used atm in any chain though.

I ran clippy autofix as well 👍🏻 