### PR TITLE
Bump `frame-metadata` to v20.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "frame-metadata"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835a2e736d544b98dab966b4b9541f15af416288a86c3738fdd67bd9fbc4696e"
+checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",
@@ -143,7 +143,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "array-bytes",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merkleized-metadata"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Bastian Köcher <git@kchr.de>"]
 documentation = "https://docs.rs/merkleized-metadata"
@@ -16,9 +16,9 @@ readme = "./README.md"
 array-bytes = { version = "6.2.2", default-features = false }
 blake3 = { version = "1.5.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.6.9", features = [ "derive" ], default-features = false }
-frame-metadata = { version = "19.0.0", features = [ "current" ], default-features = false }
+frame-metadata = { version = "20.0.0", features = [ "current" ], default-features = false }
 scale-decode = { version = "0.13.0", default-features = false }
 scale-info = { version = "2.10.0", default-features = false }
 
 [dev-dependencies]
-frame-metadata = { version = "19.0.0", features = [ "current", "decode" ], default-features = false }
+frame-metadata = { version = "20.0.0", features = [ "current", "decode" ], default-features = false }


### PR DESCRIPTION
Update `frame-metadata` to include Runtime Api version in v16.