### PR TITLE
Expose FrameMetadataPrepared and TypeInformation publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,6 @@ use frame_metadata::RuntimeMetadata;
 use merkle_tree::MerkleTree;
 pub use merkle_tree::Proof;
 use types::MetadataDigest;
-
 pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
 
 mod extrinsic_decoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@ use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
 };
 use frame_metadata::RuntimeMetadata;
+pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
 use merkle_tree::MerkleTree;
 pub use merkle_tree::Proof;
 use types::MetadataDigest;
-pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
 
 mod extrinsic_decoder;
 mod from_frame_metadata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,11 @@ use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
 };
 use frame_metadata::RuntimeMetadata;
-use from_frame_metadata::FrameMetadataPrepared;
 use merkle_tree::MerkleTree;
 pub use merkle_tree::Proof;
 use types::MetadataDigest;
+
+pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
 
 mod extrinsic_decoder;
 mod from_frame_metadata;


### PR DESCRIPTION
## Summary

- Re-export `FrameMetadataPrepared` and `TypeInformation` from the crate root so downstream consumers can access the intermediate metadata representation directly.

This is a minimal change (2 lines in `lib.rs`) that addresses #13. These types are needed by crates that want to work with the prepared metadata directly, e.g. for building custom proofs or accessing type information without going through the high-level `generate_*` functions.

Currently the only way to access these types is via the [Zondax fork](https://github.com/nickvdyck/merkleized-metadata/tree/feat/zondax-rebased), which re-exports them. Making them public upstream would let downstream users depend on the canonical crate instead.

## Changes

```diff
-use from_frame_metadata::FrameMetadataPrepared;
+pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
```

All existing tests pass.

## Test plan

- [x] `cargo test` passes (all 5 tests)
- [x] `cargo build` compiles cleanly