### PR TITLE
add proof generation for extrinsic payload

### DIFF
--- a/src/extrinsic_decoder.rs
+++ b/src/extrinsic_decoder.rs
@@ -501,6 +501,30 @@ pub fn decode_extrinsic_parts_and_collect_type_ids<'a>(
 	type_information: &TypeInformation,
 	types: impl Iterator<Item = &'a Type>,
 ) -> Result<Vec<TypeId>, String> {
+	decode_extrinsic_parts_inner(call, signed_ext_data, type_information, types, true)
+}
+
+/// Like [`decode_extrinsic_parts_and_collect_type_ids`], but only collects the types required
+/// to decode the *payload* (the `call` and the signed extensions). The `address` and
+/// `signature` types of the full extrinsic are *not* included.
+pub fn decode_extrinsic_payload_and_collect_type_ids<'a>(
+	call: &mut &[u8],
+	signed_ext_data: Option<SignedExtrinsicData>,
+	type_information: &TypeInformation,
+	types: impl Iterator<Item = &'a Type>,
+) -> Result<Vec<TypeId>, String> {
+	decode_extrinsic_parts_inner(call, signed_ext_data, type_information, types, false)
+}
+
+/// When `include_address_signature` is `true` the `address` and `signature` types are added to
+/// the collected types (full extrinsic); when `false` only the payload types are collected.
+fn decode_extrinsic_parts_inner<'a>(
+	call: &mut &[u8],
+	signed_ext_data: Option<SignedExtrinsicData>,
+	type_information: &TypeInformation,
+	types: impl Iterator<Item = &'a Type>,
+	include_address_signature: bool,
+) -> Result<Vec<TypeId>, String> {
 	let type_resolver = TypeResolver::new(types);
 
 	let visitor = CollectAccessedTypes::default();
@@ -515,14 +539,16 @@ pub fn decode_extrinsic_parts_and_collect_type_ids<'a>(
 
 	let visitor = signed_ext_data
 		.map(|mut signed_ext_data| {
-			visitor.collect_all_types(
-				&type_information.extrinsic_metadata.address_ty,
-				type_information,
-			);
-			visitor.collect_all_types(
-				&type_information.extrinsic_metadata.signature_ty,
-				type_information,
-			);
+			if include_address_signature {
+				visitor.collect_all_types(
+					&type_information.extrinsic_metadata.address_ty,
+					type_information,
+				);
+				visitor.collect_all_types(
+					&type_information.extrinsic_metadata.signature_ty,
+					type_information,
+				);
+			}
 
 			let included_in_extrinsic = &mut signed_ext_data.included_in_extrinsic;
 			let included_in_signed_data = &mut signed_ext_data.included_in_signed_data;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,11 @@
 
 extern crate alloc;
 
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
+use codec::Encode;
 use extrinsic_decoder::{
 	decode_extrinsic_and_collect_type_ids, decode_extrinsic_parts_and_collect_type_ids,
+	decode_extrinsic_payload_and_collect_type_ids,
 };
 use frame_metadata::RuntimeMetadata;
 pub use from_frame_metadata::{FrameMetadataPrepared, TypeInformation};
@@ -38,7 +40,7 @@ mod merkle_tree;
 pub mod types;
 
 /// Extra information that is required to generate the [`MetadataDigest`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode)]
 pub struct ExtraInfo {
 	/// The spec version of the runtime.
 	pub spec_version: u32,
@@ -165,6 +167,50 @@ pub fn generate_proof_for_extrinsic_parts(
 	}
 
 	MerkleTree::new(type_information.types).build_proof(accessed_types)
+}
+
+/// Generate a full proof blob for the given extrinsic payload using the given `metadata`.
+///
+/// The payload is the `call` together with the signed extension data (`signed_ext_data`),
+/// i.e. exactly the data that is signed. In contrast to
+/// [`generate_proof_for_extrinsic_parts`], the proof only contains the types required to
+/// decode this payload (the `call` and the signed extensions) and does *not* include the
+/// `address` and `signature` types of the full extrinsic. This produces the minimal proof
+/// expected by offline signers.
+///
+/// The returned bytes are the complete, SCALE-encoded proof: the merkle [`Proof`] followed
+/// by the [`types::ExtrinsicMetadata`] and the given `extra_info`.
+pub fn generate_proof_for_extrinsic_payload(
+	mut call: &[u8],
+	signed_ext_data: Option<SignedExtrinsicData>,
+	metadata: &RuntimeMetadata,
+	extra_info: &ExtraInfo,
+) -> Result<Vec<u8>, String> {
+	let prepared = FrameMetadataPrepared::prepare(metadata)?;
+	let type_information = prepared.as_type_information()?;
+
+	let call = &mut call;
+
+	let accessed_types = decode_extrinsic_payload_and_collect_type_ids(
+		call,
+		signed_ext_data,
+		&type_information,
+		type_information.types.values(),
+	)?;
+
+	if !call.is_empty() {
+		return Err("Bytes left in `call` after decoding".into());
+	}
+
+	let TypeInformation { extrinsic_metadata, types } = type_information;
+
+	let proof = MerkleTree::new(types).build_proof(accessed_types)?;
+
+	let mut encoded = proof.encode();
+	extrinsic_metadata.encode_to(&mut encoded);
+	extra_info.encode_to(&mut encoded);
+
+	Ok(encoded)
 }
 
 #[cfg(test)]

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -678,7 +678,7 @@ mod tests {
 		)
 		.unwrap();
 
-		let merkle_tree = MerkleTree::new(type_information.types);
+		let merkle_tree = MerkleTree::new(prepared.as_type_information().unwrap().types);
 		let proof = merkle_tree.build_proof(accessed).unwrap();
 
 		// The blob is the merkle proof followed by the `ExtrinsicMetadata` and the `ExtraInfo`.
@@ -686,6 +686,16 @@ mod tests {
 		extrinsic_metadata.encode_to(&mut expected);
 		extra_info.encode_to(&mut expected);
 		assert_eq!(blob, expected);
+
+		// Decoding the payload using only the proof's leaves must succeed, which proves the
+		// proof carries every type needed to decode the call and the signed extensions.
+		decode_extrinsic_payload_and_collect_type_ids(
+			&mut &call[..],
+			Some(signed_ext_data()),
+			&type_information,
+			proof.leaves.iter(),
+		)
+		.unwrap();
 
 		// The merkle proof reconstructs the metadata root.
 		let root_hash = get_hash(

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -355,16 +355,19 @@ mod tests {
 	use std::fs;
 
 	use array_bytes::Dehexify;
-	use codec::Decode;
+	use codec::{Decode, Encode};
 	use frame_metadata::RuntimeMetadataPrefixed;
 
 	use super::*;
 	use crate::{
-		extrinsic_decoder::decode_extrinsic_and_collect_type_ids,
+		extrinsic_decoder::{
+			decode_extrinsic_and_collect_type_ids, decode_extrinsic_payload_and_collect_type_ids,
+		},
 		from_frame_metadata::FrameMetadataPrepared,
 		generate_proof_for_extrinsic, generate_proof_for_extrinsic_parts,
+		generate_proof_for_extrinsic_payload,
 		types::{TypeDef, TypeDefArray, TypeRef},
-		SignedExtrinsicData,
+		ExtraInfo, SignedExtrinsicData,
 	};
 
 	#[test]
@@ -620,5 +623,84 @@ mod tests {
 			&merkle_tree,
 		);
 		assert_eq!(merkle_tree.root().hexify_prefixed(), root_hash.hexify_prefixed());
+	}
+	#[test]
+	fn generate_proof_for_payload() {
+		let metadata = String::from_utf8(
+			fs::read(format!("{}/fixtures/rococo_metadata_v15", env!("CARGO_MANIFEST_DIR")))
+				.unwrap(),
+		)
+		.unwrap();
+
+		let metadata = Option::<Vec<u8>>::decode(
+			&mut &Vec::<u8>::dehexify(metadata.strip_suffix("\n").unwrap()).unwrap()[..],
+		)
+		.unwrap()
+		.unwrap();
+
+		let metadata = RuntimeMetadataPrefixed::decode(&mut &metadata[..]).unwrap().1;
+
+		let call = Vec::<u8>::dehexify(TEST_CALL).unwrap();
+		let included_in_extrinsic = Vec::<u8>::dehexify("0x07000000").unwrap();
+		let included_in_signed_data = Vec::<u8>::dehexify(TEST_ADDITIONAL_SIGNED).unwrap();
+		let signed_ext_data = || SignedExtrinsicData {
+			included_in_extrinsic: &included_in_extrinsic,
+			included_in_signed_data: &included_in_signed_data,
+		};
+
+		let extra_info = ExtraInfo {
+			spec_version: 1006002,
+			spec_name: "rococo".into(),
+			base58_prefix: 42,
+			decimals: 12,
+			token_symbol: "ROC".into(),
+		};
+
+		let blob = generate_proof_for_extrinsic_payload(
+			&call,
+			Some(signed_ext_data()),
+			&metadata,
+			&extra_info,
+		)
+		.unwrap();
+
+		// Reconstruct the pieces from the metadata so the blob is validated without depending on
+		// any external reference.
+		let prepared = FrameMetadataPrepared::prepare(&metadata).unwrap();
+		let type_information = prepared.as_type_information().unwrap();
+		let extrinsic_metadata = type_information.extrinsic_metadata.clone();
+
+		let accessed = decode_extrinsic_payload_and_collect_type_ids(
+			&mut &call[..],
+			Some(signed_ext_data()),
+			&type_information,
+			type_information.types.values(),
+		)
+		.unwrap();
+
+		let merkle_tree = MerkleTree::new(type_information.types);
+		let proof = merkle_tree.build_proof(accessed).unwrap();
+
+		// The blob is the merkle proof followed by the `ExtrinsicMetadata` and the `ExtraInfo`.
+		let mut expected = proof.encode();
+		extrinsic_metadata.encode_to(&mut expected);
+		extra_info.encode_to(&mut expected);
+		assert_eq!(blob, expected);
+
+		// The merkle proof reconstructs the metadata root.
+		let root_hash = get_hash(
+			&mut &proof.leaf_indices[..],
+			&mut &proof.leaves[..],
+			&mut &proof.nodes[..],
+			NodeIndex(0),
+			&merkle_tree,
+		);
+		assert_eq!(merkle_tree.root().hexify_prefixed(), root_hash.hexify_prefixed());
+
+		// The payload proof omits the unused `address` / `signature` variants that the full
+		// "parts" proof includes, so it has fewer leaves.
+		let parts_proof =
+			generate_proof_for_extrinsic_parts(&call, Some(signed_ext_data()), &metadata).unwrap();
+		assert!(proof.leaves.len() < parts_proof.leaves.len());
 	}
 }


### PR DESCRIPTION
### Description

`generate_proof_for_extrinsic_parts` builds a proof for the full extrinsic, so it includes the `address` and `signature` types (all their variants). It also returns only the merkle `Proof`, without the `ExtrinsicMetadata` and `ExtraInfo`.

This PR adds `generate_proof_for_extrinsic_payload`, which builds a proof for just the signed payload (call + signed extensions, no address/signature) and returns the complete blob: the merkle proof followed by the `ExtrinsicMetadata` and `ExtraInfo`. `ExtraInfo` now derives `Encode`. The existing `generate_proof_for_extrinsic_parts` is unchanged.

### Changes per file

- `src/lib.rs`: derive `Encode` for `ExtraInfo`; add `generate_proof_for_extrinsic_payload`, which collects the payload types, builds the proof, and returns `proof.encode()` + `ExtrinsicMetadata` + `ExtraInfo`.
- `src/extrinsic_decoder.rs`: add a payload type collector that goes through the call and the signed extensions only (no `address`/`signature`). Shared logic with the existing parts collector is moved into a private helper with a flag; parts behaviour is unchanged.
- `src/merkle_tree.rs`: add a test (reuses the existing `rococo` fixture) that checks the blob layout, that the payload decodes using only the proof's leaves (the proof carries every type needed), that the proof rebuilds the metadata root, and that it has fewer leaves than the parts proof.